### PR TITLE
卓組表サイトのURLをhttpsにする

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
       <ul>
         <li><a href="https://atcoder-type-checker.herokuapp.com/">AtCoder Type Checker</a></li>
         <li><a href="https://check-mahjong-hand.herokuapp.com/">麻雀の待ち判定・全アガリ形列挙 (オールマイティ牌・銀河牌対応)</a></li>
-        <li><a href="http://tomii6614.web.fc2.com/">麻雀大会用卓組表</a></li>
+        <li><a href="https://tomii6614.web.fc2.com/">麻雀大会用卓組表</a></li>
         <li>
           X (Twitter) bot
           <ul>


### PR DESCRIPTION
設定変更で SSL に対応したので

## 参考

- https://github.com/tomii9273/mahjong_takugumi/issues/1