### PR TITLE
統計検定を準1級に更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,9 +67,9 @@
     <section id="qualifications">
       <h2>Qualifications</h2>
       <ul>
+        <li>2023.12 統計検定 準1級 合格</li>
         <li>2023.09 <a href="https://past.atcoder.jp/">アルゴリズム実技検定</a> エキスパート 取得 (有効期限: 2025.09)</li>
         <li>2023.06 TOEIC公開テスト 835点 取得</li>
-        <li>2023.04 統計検定 2級 合格</li>
         <li>2021.10 応用情報技術者試験 合格</li>
         <li>2018.03 甲種危険物取扱者 取得</li>
       </ul>


### PR DESCRIPTION
2023.12.11 に 統計検定の準1級 (CBT) に合格したので追加。
項目が多くなりすぎるので、2級は削除した。