### PR TITLE
Google Cloud 資格 ACE 追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,11 @@
     <section id="qualifications">
       <h2>Qualifications</h2>
       <ul>
+        <li>
+          2024.01
+          <a href="https://google.accredible.com/cf1b9256-400f-47fc-a6ca-c1d39bb49980">Google Cloud 認定資格 Associate Cloud Engineer 取得</a>
+          (有効期限: 2027.01)
+        </li>
         <li>2023.12 データベーススペシャリスト試験 合格</li>
         <li>2023.12 統計検定 準1級 合格</li>
         <li>2023.09 <a href="https://past.atcoder.jp/">アルゴリズム実技検定</a> エキスパート 取得 (有効期限: 2025.09)</li>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
         <li>Python</li>
         <li>機械学習</li>
         <li>アルゴリズムとデータ構造</li>
-        <li>SQL (BigQuery)</li>
+        <li>SQL (BigQuery を主に使用)</li>
         <li>Google Cloud (旧 GCP)</li>
         <li>有機化学</li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
         <li>機械学習</li>
         <li>アルゴリズムとデータ構造</li>
         <li>SQL (BigQuery)</li>
+        <li>Google Cloud (旧 GCP)</li>
         <li>有機化学</li>
       </ul>
     </section>


### PR DESCRIPTION
- 2024.01.08 に Google Cloud 認定資格 Associate Cloud Engineer をテストセンターで受験し合格したので追加。
  - 合否は受験終了時に暫定結果が表示されるが、正式には数日後のメールで決まる。今回は翌日にメールが来た。厳密な有効期間は受験日から3年らしい。
- Skills にも書いた。
- LinkedIn にも追加。